### PR TITLE
Remove duplicated "current-goroutines" tag

### DIFF
--- a/span.go
+++ b/span.go
@@ -64,10 +64,7 @@ func StartSpanWithHeader(header *http.Header, operationName, method, path string
 	if header != nil {
 		wireContext, _ = opentracing.GlobalTracer().Extract(opentracing.HTTPHeaders, opentracing.HTTPHeadersCarrier(*header))
 	}
-	span := StartSpanWithParent(wireContext, operationName, method, path)
-	span.SetTag("current-goroutines", runtime.NumGoroutine())
-	return span
-	// return StartSpanWithParent(wireContext, operationName, method, path)
+	return StartSpanWithParent(wireContext, operationName, method, path)
 }
 
 // InjectTraceID injects the span ID into the provided HTTP header object, so that the


### PR DESCRIPTION
I'm getting this warning on my Jaeger UI:

![image](https://user-images.githubusercontent.com/4842605/99546656-69649f00-2995-11eb-9a74-0048ba8fd7fd.png)

That is because the tag is already added on `StartSpanWithParent`, and is being added a second time on `StartSpanWithHeader`